### PR TITLE
ask about codeword and show instructions on demand

### DIFF
--- a/code/table.R
+++ b/code/table.R
@@ -35,7 +35,22 @@ df2google <- function(survey_df, sheet_link) {
   write_sheet(survey_df, ss = gs4_get(sheet_link), sheet = "Sheet1")
 }
 
+add_codeword_instructions <- function() {
+  path_codeword_yml <- here::here("surveys", "codeword.yml")
+  codeword_df <- yml2df(yml_file = path_codeword_yml)
+  codeword_instructions <- codeword_df %>%
+    .[name == "instructions", ] %>%
+    .$label
+}
+
 opt <- get_input()
 survey <- surveys[grepl(x = surveys, pattern = opt$survey)]
 sheet_link <- sheets[[opt$survey]]
-df2google(yml2df(yml_file = survey), sheet_link = sheet_link)
+survey_df <- yml2df(yml_file = survey)
+if (any(survey_df$name %in% "codeword_instructions")) {
+  # add codeword instructions if required:
+  codeword_instructions <- add_codeword_instructions()
+  survey_df$label[survey_df$name == "codeword_instructions"] <- codeword_instructions
+}
+df2google(survey_df, sheet_link = sheet_link)
+survey <- surveys[grepl(x = surveys, pattern = opt$survey)]

--- a/surveys/basics.yml
+++ b/surveys/basics.yml
@@ -14,6 +14,24 @@ intro_note:
     ## Welcome to this survey!
     This survey is part of the course "version control of data and code"" by Lennart Wittkuhn.
     All answers are anonymous and free text items will not be shared with everyone.
+    ### Codeword
+codeword:
+  type: text 8
+  class: label_align_left
+  name: codeword
+  label: |
+    **Please enter your personal codeword:**
+codeword_check:
+  class: |
+    label_align_left
+  type: mc_multiple
+  name: codeword_check
+  choice1: "Show codeword instructions"
+codeword_instructions:
+  type: note
+  name: codeword_instructions
+  label: "Instructions missing!"
+  showif: codeword_check == 1
 note_start:
   class: label_align_left
   type: note

--- a/surveys/cli.yml
+++ b/surveys/cli.yml
@@ -14,6 +14,24 @@ intro_note:
     ## Welcome to this survey!
     This survey is part of the course "version control of data and code"" by Lennart Wittkuhn.
     All answers are anonymous and free text items will not be shared with everyone.
+    ### Codeword
+codeword:
+  type: text 8
+  class: label_align_left
+  name: codeword
+  label: |
+    **Please enter your personal codeword:**
+codeword_check:
+  class: |
+    label_align_left
+  type: mc_multiple
+  name: codeword_check
+  choice1: "Show codeword instructions"
+codeword_instructions:
+  type: note
+  name: codeword_instructions
+  label: "Instructions missing!"
+  showif: codeword_check == 1
 note_start:
   class: label_align_left
   type: note

--- a/surveys/codeword.yml
+++ b/surveys/codeword.yml
@@ -30,8 +30,12 @@ instructions:
     - Your birthday: **09**.11.1987
 
     This results in the following code word: **ER04LF09**
-    
-    #### Please enter your code word in the boxes:
+input_heading:
+  class: label_align_left
+  type: note
+  name: input_heading
+  label: |
+    ### Please enter your code word in the boxes:
 mother_letters:
   type: letters 2
   class: label_align_left

--- a/surveys/intro.yml
+++ b/surveys/intro.yml
@@ -6,7 +6,6 @@ browser:
   name: browser
 intro_note:
   class: |
-    answer_below_label
     label_align_left
   type: note
   name: intro_note
@@ -14,6 +13,24 @@ intro_note:
     ### Welcome to this survey!
     This survey is part of the course "version control of data and code"" by Lennart Wittkuhn.
     All answers are anonymous and free text items will not be shared with everyone.
+    ### Codeword
+codeword:
+  type: text 8
+  class: label_align_left
+  name: codeword
+  label: |
+    **Please enter your personal codeword:**
+codeword_check:
+  class: |
+    label_align_left
+  type: mc_multiple
+  name: codeword_check
+  choice1: "Show codeword instructions"
+codeword_instructions:
+  type: note
+  name: codeword_instructions
+  label: "Instructions missing!"
+  showif: codeword_check == 1
 about_note:
   class: |
     answer_below_label


### PR DESCRIPTION
hey @konradpa, I hacked some code together that asks about the codeword in the beginning of the survey and injects the codword instructions from `surveys/codeword.yml`. so far, this is only included in `surveys/intro.yml`.

Could you please review, take over from here and:

- [x] check if the code works on your end, too? running `make intro` should be sufficient.
- [x] add the chunk of the `intro.yml`that includes the codeword part (see [here](https://github.com/lnnrtwttkhn/version-control-survey/commit/77646af030e330ca9f27b728fae29ed3ca83739a#diff-dac72a2189adafbb1a71df13513ccae30054955180b47fa7ac4e083eef5460a2)) in all other surveys as well (but perhaps we should close #9 first)

thank you!

fixes #3